### PR TITLE
Add sent/read indicators

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
@@ -66,18 +66,13 @@ class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.Vi
     }
 
     override fun onError(exception: String) {
-        runOnUiThread {
-            txtMessage.isEnabled = false
-            lblError.text = exception
-            recyclerViewMessages.visibility = View.GONE
-        }
-
+        txtMessage.isEnabled = false
+        lblError.text = exception
+        recyclerViewMessages.visibility = View.GONE
     }
 
     override fun onConnected(person: CurrentUser) {
-        runOnUiThread {
-            Toast.makeText(this, "connected", Toast.LENGTH_SHORT).show()
-        }
+        Toast.makeText(this, "connected", Toast.LENGTH_SHORT).show()
     }
 
     private fun displayPresence(presence: Presence) {
@@ -88,7 +83,6 @@ class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.Vi
 
             imgStatus.setImageDrawable(wrappedDrawable)
         } else {
-
             val unwrappedDrawable = AppCompatResources.getDrawable(applicationContext, R.drawable.icon_profile_outline)
             val wrappedDrawable = DrawableCompat.wrap(unwrappedDrawable!!)
             DrawableCompat.setTint(wrappedDrawable, ContextCompat.getColor(applicationContext, R.color.light_purple))
@@ -98,30 +92,21 @@ class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.Vi
     }
 
     override fun onOtherMember(person: User) {
-        runOnUiThread {
-            lblName.text = person.name
-            displayPresence(person.presence)
-        }
-
+        lblName.text = person.name
+        displayPresence(person.presence)
     }
 
     override fun onOtherMemberPresenceChanged(person: User) {
-        runOnUiThread {
-            displayPresence(person.presence)
-        }
+        displayPresence(person.presence)
     }
 
     override fun onMessageReceived(message: Message) {
-        runOnUiThread {
-            adapter.addMessage(message)
-            recyclerViewMessages.layoutManager?.scrollToPosition(adapter.itemCount - 1)
-        }
+        adapter.addMessage(message)
+        recyclerViewMessages.layoutManager?.scrollToPosition(adapter.itemCount - 1)
     }
 
     override fun onOtherMemberReadCursorChanged(messageId: Int) {
-        runOnUiThread {
-            adapter.markAsReadUpTo(messageId)
-        }
+        adapter.markAsReadUpTo(messageId)
     }
 
 }

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
@@ -58,7 +58,6 @@ class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.Vi
                 }
             }
 
-            //tell our presenter to connect as the seller user
             presenter.connect()
         } else {
             onError("Current user was not found - have you signed in?")

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatActivity.kt
@@ -15,17 +15,11 @@ import com.pusher.chatkit.presence.Presence
 import com.pusher.chatkit.users.User
 import com.pusher.demo.R
 import com.pusher.demo.features.marketplace.ChatkitManager
-import com.pusher.demo.features.marketplace.chat.MessageAdapter.MessageDisplayedListener
 import kotlinx.android.synthetic.main.activity_marketplace_chat.*
 
 class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.View {
 
     private lateinit var adapter: MessageAdapter
-    private val messageDisplayedListener = object : MessageDisplayedListener {
-        override fun onMessageDisplayed(message: Message) {
-            presenter.onMessageDisplayed(message)
-        }
-    }
 
     private val presenter = MarketplaceChatPresenter()
 
@@ -37,7 +31,10 @@ class MarketplaceChatActivity : AppCompatActivity(), MarketplaceChatPresenter.Vi
 
         if (ChatkitManager.currentUser != null) {
             //set up our recyclerview adapter
-            adapter = MessageAdapter(ChatkitManager.currentUser!!.id, messageDisplayedListener)
+            adapter = MessageAdapter(ChatkitManager.currentUser!!.id) {
+                presenter.onMessageDisplayed(it)
+            }
+
             val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
             layoutManager.stackFromEnd = true
             recyclerViewMessages.layoutManager =  layoutManager

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatPresenter.kt
@@ -1,8 +1,7 @@
 package com.pusher.demo.features.marketplace.chat
 
-import android.content.Context
+import android.os.Handler
 import android.util.Log
-import com.pusher.chatkit.*
 import com.pusher.chatkit.CurrentUser
 import com.pusher.chatkit.messages.multipart.Message
 import com.pusher.chatkit.rooms.Room
@@ -15,14 +14,22 @@ import com.pusher.util.Result
 class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>(){
 
     interface View {
-        fun onError(exception: String)
         fun onConnected(person: CurrentUser)
+
         fun onOtherMember(person: User)
-        fun onMemberPresenceChanged(person: User)
+        fun onOtherMemberPresenceChanged(person: User)
+        fun onOtherMemberReadCursorChanged(messageId: Int)
+
         fun onMessageReceived(message: Message)
+
+        fun onError(exception: String)
     }
 
+    private val handler = Handler()
+
     private lateinit var room: Room
+
+    private var lastReadByCurrentUserMessageId = -1
 
     fun connect() {
         subscribeToRoom()
@@ -34,43 +41,50 @@ class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>()
             return
         }
 
-        room = ChatkitManager.currentUser!!.rooms.find { room -> room.name == "buyer:seller" }!!
+        room = currentUser().rooms.find { room -> room.name == "buyer:seller" }!!
 
         //subscribe to the room
-        ChatkitManager.currentUser!!.subscribeToRoomMultipart(
+        currentUser().subscribeToRoomMultipart(
             roomId = room.id ,
             listeners = RoomListeners(
                 onMultipartMessage = { message ->
                     view?.onMessageReceived(message)
-                    updateReadCursor(room.id, message.id)
                 },
                 onPresenceChange = { person ->
-                    if (isViewAttached() &&
-                            person.id != ChatkitManager.currentUser!!.id) {
-                        view?.onMemberPresenceChanged(person)
+                    if (person.id != currentUser().id) {
+                        view?.onOtherMemberPresenceChanged(person)
+                    }
+                },
+                onNewReadCursor = { cursor ->
+                    if (cursor.userId != currentUser().id) {
+                        view?.onOtherMemberReadCursorChanged(cursor.position)
                     }
                 }
             ),
             messageLimit = 20,
             callback = { subscription ->
                 //success
-                getMembersForRoom(room)
+                handler.post {
+                    getCurrentUserReadCursor(room)
+                    getOtherMemberInfo(room)
+                }
             }
         )
     }
 
-    private fun getMembersForRoom(room: Room){
+    private fun getOtherMemberInfo(room: Room){
         //get members for room
-        ChatkitManager.currentUser!!.usersForRoom( room.id, callback = { result ->
+        currentUser().usersForRoom( room.id, callback = { result ->
             when (result) {
                 is Result.Success -> {
                     result.value.let { members ->
                         //check we actually have another user to talk to
-                        val otherMember = members.find { user-> user.id != ChatkitManager.currentUser!!.id }
+                        val otherMember = members.find { user-> user.id != currentUser().id }
                         if (otherMember == null) {
                             handleError("could not find the other user to talk to - " +
                                     "have you created the sample data?")
                         } else {
+                            getOtherMemberReadCursor(room, otherMember)
                             view?.onOtherMember(otherMember)
                         }
                     }
@@ -84,9 +98,27 @@ class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>()
         })
     }
 
-    fun sendMessageToRoom(message: String) {
+    private fun getOtherMemberReadCursor(room: Room, otherMember : User) {
+        val readCursor = currentUser().getReadCursor(room, otherMember).successOrThrow()
+        view?.onOtherMemberReadCursorChanged(readCursor.position)
+    }
 
-        ChatkitManager.currentUser!!.sendSimpleMessage(room, message,
+    private fun getCurrentUserReadCursor(room: Room) {
+        val readCursor = currentUser().getReadCursor(room).successOrThrow()
+        lastReadByCurrentUserMessageId = readCursor.position
+    }
+
+    fun onMessageDisplayed(message: Message) {
+        if (message.sender.id != currentUser().id) {
+            if (lastReadByCurrentUserMessageId < message.id) {
+                lastReadByCurrentUserMessageId = message.id
+                updateReadCursor(room.id, lastReadByCurrentUserMessageId)
+            }
+        }
+    }
+
+    fun sendMessageToRoom(message: String) {
+        currentUser().sendSimpleMessage(room, message,
             callback = { result ->
                 when (result) {
 
@@ -100,8 +132,8 @@ class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>()
         })
     }
 
-    private fun updateReadCursor(roomId: String ,messageId: Int) {
-        ChatkitManager.currentUser!!.setReadCursor(roomId, messageId)
+    private fun updateReadCursor(roomId: String, messageId: Int) {
+        currentUser().setReadCursor(roomId, messageId)
     }
 
     private fun handleError(error: String) {
@@ -110,3 +142,5 @@ class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>()
     }
 
 }
+
+private fun currentUser() = ChatkitManager.currentUser!!

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
@@ -6,12 +6,8 @@ import com.pusher.chatkit.messages.multipart.Message
 import com.pusher.demo.R
 
 class MessageAdapter(private val currentUserId: String,
-                     private val messageDisplayedListener : MessageDisplayedListener)
+                     private val messageDisplayedListener : (message: Message) -> Unit)
     : androidx.recyclerview.widget.RecyclerView.Adapter<MessageViewHolder>() {
-
-    interface MessageDisplayedListener {
-        fun onMessageDisplayed(message: Message)
-    }
 
     private var messages = mutableListOf<Message>()
 
@@ -36,7 +32,7 @@ class MessageAdapter(private val currentUserId: String,
         val read = message.id <= lastReadByOtherMemberMessageId
         holder.markAsRead(isCurrentUserMessage && read)
 
-        messageDisplayedListener.onMessageDisplayed(message)
+        messageDisplayedListener(message)
     }
 
     fun addMessage(message: Message) {

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
@@ -5,10 +5,17 @@ import android.view.ViewGroup
 import com.pusher.chatkit.messages.multipart.Message
 import com.pusher.demo.R
 
-class MessageAdapter(private val currentUserId: String)
+class MessageAdapter(private val currentUserId: String,
+                     private val messageDisplayedListener : MessageDisplayedListener)
     : androidx.recyclerview.widget.RecyclerView.Adapter<MessageViewHolder>() {
 
-    var messages = mutableListOf<Message>()
+    interface MessageDisplayedListener {
+        fun onMessageDisplayed(message: Message)
+    }
+
+    private var messages = mutableListOf<Message>()
+
+    private var lastReadByOtherMemberMessageId = -1
 
     override fun onCreateViewHolder(parent: ViewGroup, p1: Int): MessageViewHolder {
         return MessageViewHolder(
@@ -22,13 +29,24 @@ class MessageAdapter(private val currentUserId: String)
     }
 
     override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
-        holder.bind(messages[position], currentUserId)
+        val message = messages[position]
+        holder.bind(message, currentUserId)
+
+        val isCurrentUserMessage = message.sender.id == currentUserId
+        val read = message.id <= lastReadByOtherMemberMessageId
+        holder.markAsRead(isCurrentUserMessage && read)
+
+        messageDisplayedListener.onMessageDisplayed(message)
     }
 
     fun addMessage(message: Message) {
-        this.messages.add(message)
-        notifyItemInserted(this.messages.size)
+        messages.add(message)
+        notifyItemInserted(messages.size)
     }
 
+    fun markAsReadUpTo(messageId: Int) {
+        lastReadByOtherMemberMessageId = messageId
+        notifyDataSetChanged()
+    }
 
 }

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
@@ -28,9 +28,9 @@ class MessageAdapter(private val currentUserId: String,
         val message = messages[position]
         holder.bind(message, currentUserId)
 
-        val isCurrentUserMessage = message.sender.id == currentUserId
+        val currentUserMessage = message.sender.id == currentUserId
         val read = message.id <= lastReadByOtherMemberMessageId
-        holder.markAsRead(isCurrentUserMessage && read)
+        holder.markAsRead(currentUserMessage && read)
 
         messageDisplayedListener(message)
     }

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageAdapter.kt
@@ -6,7 +6,7 @@ import com.pusher.chatkit.messages.multipart.Message
 import com.pusher.demo.R
 
 class MessageAdapter(private val currentUserId: String,
-                     private val messageDisplayedListener : (message: Message) -> Unit)
+                     private val messageDisplayedListener : (Message) -> Unit)
     : androidx.recyclerview.widget.RecyclerView.Adapter<MessageViewHolder>() {
 
     private var messages = mutableListOf<Message>()

--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageViewHolder.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MessageViewHolder.kt
@@ -3,23 +3,34 @@ package com.pusher.demo.features.marketplace.chat
 import android.view.View
 import com.pusher.chatkit.messages.multipart.Message
 import com.pusher.chatkit.messages.multipart.Payload
+import com.pusher.demo.R
 import kotlinx.android.synthetic.main.row_message.view.*
-
 
 class MessageViewHolder (itemView: View)
     : androidx.recyclerview.widget.RecyclerView.ViewHolder(itemView) {
 
     fun bind(message: Message, currentUserId: String){
-
         val inlineMessage: Payload.Inline = message.parts[0].payload as Payload.Inline
         if (message.sender.id == currentUserId) {
             itemView.lblMessageFromYou.visibility = View.VISIBLE
             itemView.lblMessageFromYou.text = inlineMessage.content
+            itemView.lblMessageFromOther.visibility = View.GONE
         } else {
             itemView.lblMessageFromOther.visibility = View.VISIBLE
             itemView.lblMessageFromOther.text = inlineMessage.content
+            itemView.lblMessageFromYou.visibility = View.GONE
+        }
+    }
+
+    fun markAsRead(read: Boolean) {
+        val sentOrReadDrawableResId = if (read) {
+            R.drawable.read_indicator
+        } else {
+            R.drawable.sent_indicator
         }
 
+        itemView.lblMessageFromYou.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0,
+            sentOrReadDrawableResId, 0)
     }
 
 }

--- a/app/src/main/res/drawable/read_indicator.xml
+++ b/app/src/main/res/drawable/read_indicator.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#ff33b5e5"
+      android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/app/src/main/res/drawable/sent_indicator.xml
+++ b/app/src/main/res/drawable/sent_indicator.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#aaa"
+      android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/app/src/main/res/layout/row_message.xml
+++ b/app/src/main/res/layout/row_message.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -9,7 +10,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="16sp"
-            android:text="DANIELLE"
             android:textColor="@color/light_text"
             android:layout_marginStart="10dp"
             android:layout_marginEnd="50dp"
@@ -19,7 +19,7 @@
             android:gravity="start"
             android:background="@drawable/message_bubble_other"
             android:visibility="gone"
-    />
+            tools:text="Message from the seller" />
 
     <TextView
             android:id="@+id/lblMessageFromYou"
@@ -27,7 +27,6 @@
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:textSize="16sp"
-            android:text="DANIELLE"
             android:textColor="@color/light_text"
             android:layout_marginStart="50dp"
             android:layout_marginEnd="10dp"
@@ -37,6 +36,9 @@
             android:gravity="end"
             android:background="@drawable/message_bubble_you"
             android:visibility="gone"
-    />
+            android:drawablePadding="4dp"
+            android:drawableEnd="@drawable/sent_indicator"
+            tools:text="Message from the buyer"
+            tools:visibility="visible" />
 
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
![Screenshot_1574162921](https://user-images.githubusercontent.com/8502071/69142925-c0544180-0abf-11ea-8d6d-814c8ab4aae3.png)

Also [fixes](https://github.com/pusher/chatkit-android-public-demo/compare/read-indicators?expand=1#diff-4e9423356569554ba6805c0a3b7652a3R17) view recycling issue of incorrect party's messages randomly appearing while scrolling through the message history.

Also [adds](https://github.com/pusher/chatkit-android-public-demo/compare/read-indicators?expand=1#diff-e0e5521ca2c9b511f61f4637dd2ba1aeR47) a handy feature when testing on emulator of the ENTER key as well triggering sending a message. Also adding prevention to not send an empty message.

Includes automatic IDE's updates: [1](https://github.com/pusher/chatkit-android-public-demo/compare/read-indicators?expand=1#diff-c197962302397baf3a4cc36463dce5eaR11) and [2](https://github.com/pusher/chatkit-android-public-demo/compare/read-indicators?expand=1#diff-c0176795f4ea97568151067bbe2f0bb5R3)