### PR TITLE
Fix issue where cursors could be null

### DIFF
--- a/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/chat/MarketplaceChatPresenter.kt
@@ -13,6 +13,8 @@ import com.pusher.util.Result
 
 class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>(){
 
+    val LOG_TAG = "DEMO_APP"
+
     interface View {
         fun onConnected(person: CurrentUser)
 
@@ -110,29 +112,26 @@ class MarketplaceChatPresenter :  BasePresenter<MarketplaceChatPresenter.View>()
 
     private fun getOtherMemberReadCursor(room: Room, otherMember : User) {
         currentUser().getReadCursor(room, otherMember).fold(
+            onSuccess = {
+                view?.onOtherMemberReadCursorChanged(it.position)
+            },
             onFailure = {
                 // this situation can happen when the room has just been created, and the other
                 // persons cursor has not yet been created as they have not yet read any messages.
-                Log.d(ChatkitManager.LOG_TAG, "failed to create the other members cursor")
-            },
-            onSuccess = {
-                view?.onOtherMemberReadCursorChanged(it.position)
-            })
-    }
-
-    private fun updateCurrentUserMessageId(messageId: Int) {
-        lastReadByCurrentUserMessageId = messageId
+                Log.d(LOG_TAG, "other member's cursor not set yet")
+            }
+        )
     }
 
     private fun getCurrentUserReadCursor(room: Room) {
         currentUser().getReadCursor(room).fold(
+            onSuccess = {
+                lastReadByCurrentUserMessageId = it.position
+            },
             onFailure = {
                 // this situation can happen when the room has just been created, and your current
                 // users cursor has not yet been created as they have not yet read any messages.
-                Log.d(ChatkitManager.LOG_TAG, "failed to create the other members cursor")
-            },
-            onSuccess = {
-                updateCurrentUserMessageId(it.position)
+                Log.d(LOG_TAG, "current member's cursor not set yet")
             }
         )
     }


### PR DESCRIPTION
What
Added error handling around getting cursors.

Why
If the room has newly been created, it's possible that the nobody has read any messages (none will have been sent), and therefor there will be no cursors! This code now handles that error case by logging to the console that there was no cursor.

The other users cursor will be provided in the onNewCursor event as soon as they've read another message, so the app will continue to work as expected.

Questions:
* I explained why this could happen to potential developers in a comment above the console log - should i put this explanation in the log message instead? My thinking was to write the comment to explain to others when they look at the code why that might happen. Do the two messages make sense?