### PR TITLE
Consume v7 memberships update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
 
     //chatkit library
+    //todo: revert this before releasing
 //    implementation 'com.pusher:chatkit-android:1.8.0'
     implementation 'com.github.pusher:chatkit-android:49394fa0fc57ab558213369dfdcce9877e8ee197'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
 
     //chatkit library
-    implementation 'com.pusher:chatkit-android:1.8.0'
+//    implementation 'com.pusher:chatkit-android:1.8.0'
+    implementation 'com.github.pusher:chatkit-android:49394fa0fc57ab558213369dfdcce9877e8ee197'
 
     //push notifications
     implementation 'com.google.firebase:firebase-analytics:17.2.0'

--- a/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
@@ -9,8 +9,8 @@ import com.pusher.util.Result
 
 object ChatkitManager {
 
-    private val INSTANCE_LOCATOR = "FILL_ME_IN"
-    private val TOKEN_PROVIDER_URL = "FILL_ME_IN"
+    private val INSTANCE_LOCATOR = "v1:us1:ddcaffd5-b8cf-49c8-b6ff-441b89b75895"
+    private val TOKEN_PROVIDER_URL = "https://us1.pusherplatform.io/services/chatkit_token_provider/v1/ddcaffd5-b8cf-49c8-b6ff-441b89b75895/token"
     val LOG_TAG = "DEMO_APP"
 
     private lateinit var chatManager: ChatManager

--- a/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
@@ -9,8 +9,8 @@ import com.pusher.util.Result
 
 object ChatkitManager {
 
-    private val INSTANCE_LOCATOR = "v1:us1:ddcaffd5-b8cf-49c8-b6ff-441b89b75895"
-    private val TOKEN_PROVIDER_URL = "https://us1.pusherplatform.io/services/chatkit_token_provider/v1/ddcaffd5-b8cf-49c8-b6ff-441b89b75895/token"
+    private val INSTANCE_LOCATOR = "FILL_ME_IN"
+    private val TOKEN_PROVIDER_URL = "FILL_ME_IN"
     val LOG_TAG = "DEMO_APP"
 
     private lateinit var chatManager: ChatManager

--- a/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
@@ -21,11 +21,6 @@ object ChatkitManager {
         fun onError(error: String)
     }
 
-    interface JoinedRoomsMembersListener {
-        fun onMembersFetched(members: List<User>)
-        fun onError(error: String)
-    }
-
     private var chatListeners = ArrayList<ChatListeners>()
     fun addChatListener(listener: ChatListeners) {
         chatListeners.add(listener)
@@ -107,19 +102,6 @@ object ChatkitManager {
                 }
             }
         )
-    }
-
-    fun getUsersFromMyJoinedRooms(listener: JoinedRoomsMembersListener) {
-        currentUser!!.users {
-            when (it) {
-                is Result.Success -> {
-                    listener.onMembersFetched(it.value)
-                }
-                is Result.Failure -> {
-                    listener.onError(it.error.reason)
-                }
-            }
-        }
     }
 
 }

--- a/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/ChatkitManager.kt
@@ -21,8 +21,8 @@ object ChatkitManager {
         fun onError(error: String)
     }
 
-    interface ChatManagerAllUsersListener {
-        fun onUsers(users: List<User>)
+    interface JoinedRoomsMembersListener {
+        fun onMembersFetched(members: List<User>)
         fun onError(error: String)
     }
 
@@ -109,11 +109,11 @@ object ChatkitManager {
         )
     }
 
-    fun getAllUsersInitialState(listener: ChatkitManager.ChatManagerAllUsersListener) {
+    fun getUsersFromMyJoinedRooms(listener: JoinedRoomsMembersListener) {
         currentUser!!.users {
             when (it) {
                 is Result.Success -> {
-                    listener.onUsers(it.value)
+                    listener.onMembersFetched(it.value)
                 }
                 is Result.Failure -> {
                     listener.onError(it.error.reason)

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
@@ -52,7 +52,8 @@ class SellerActivity : AppCompatActivity(),
         // because we only have 1 product we can assume all conversations are to dow ith it!
 
         lblConversationsTitle.text =
-            resources.getQuantityText(R.plurals.numberOfPeopleInterested, rooms.size)
+            resources.getQuantityString(R.plurals.numberOfPeopleInterested,
+                rooms.size, rooms.size)
 
         val context = this
         //set up our recyclerview

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
@@ -31,6 +31,11 @@ class SellerActivity : AppCompatActivity(),
 
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        presenter.endSubscriptionToRoomUpdates()
+    }
+
     override fun onConnected(user: CurrentUser) {
         //display all the conversations
         runOnUiThread {
@@ -66,10 +71,7 @@ class SellerActivity : AppCompatActivity(),
         recyclerViewPeople.layoutManager =  LinearLayoutManager(this)
         recyclerViewPeople.adapter = adapter
 
-        //currently we have to subscribe to the room to get the people but we can change this soon!
-        for (room in rooms) {
-            presenter.subscribeToRoom(room)
-        }
+        presenter.subscribeToRoomUpdates()
 
     }
 

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerActivity.kt
@@ -89,7 +89,7 @@ class SellerActivity : AppCompatActivity(),
         }
     }
 
-    override fun onPerson(user: User, room: Room) {
+    override fun onBuyer(user: User, room: Room) {
         runOnUiThread {
             adapter.addPerson(user, room)
         }

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -88,7 +88,7 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
                 view?.onError(error)
             } else {
 
-                val otherPerson = users.find{ user -> user.id == otherMemberId}
+                val otherMember = users.find{ user -> user.id == otherMemberId}!!
 
                 if (otherPerson == null) {
                     val error = "Couldn't match the user id:$otherMemberId to a user object"

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -6,11 +6,9 @@ import com.pusher.chatkit.ChatListeners
 import com.pusher.chatkit.CurrentUser
 import com.pusher.chatkit.presence.Presence
 import com.pusher.chatkit.rooms.Room
-import com.pusher.chatkit.rooms.RoomListeners
 import com.pusher.chatkit.users.User
 import com.pusher.demo.features.BasePresenter
 import com.pusher.demo.features.marketplace.ChatkitManager
-import com.pusher.util.Result
 
 class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
@@ -65,7 +63,7 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
         ChatkitManager.getUsersFromMyJoinedRooms(object: ChatkitManager.JoinedRoomsMembersListener {
             override fun onMembersFetched(members: List<User>) {
-                reconcileUsers(members)
+                reconcileFetchedBuyers(members)
             }
 
             override fun onError(error: String) {
@@ -76,29 +74,13 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
     }
 
-    private fun reconcileUsers(users: List<User>) {
+    private fun reconcileFetchedBuyers(buyers: List<User>) {
 
         for (room in ChatkitManager.currentUser!!.rooms) {
 
             val otherMemberId = room.memberUserIds.find { userId-> userId != ChatkitManager.currentUser!!.id }!!
-
-            if (otherMemberId == null) {
-                val error = "Couldn't find any other people in room " + room.name
-                Log.e(ChatkitManager.LOG_TAG, error)
-                view?.onError(error)
-            } else {
-
-                val otherMember = users.find{ user -> user.id == otherMemberId}!!
-
-                if (otherPerson == null) {
-                    val error = "Couldn't match the user id:$otherMemberId to a user object"
-                    Log.e(ChatkitManager.LOG_TAG, error)
-                    view?.onError(error)
-                } else {
-                    view?.onPerson(otherPerson, room)
-                }
-
-            }
+            val otherMember = buyers.find{ user -> user.id == otherMemberId}!!
+            view?.onPerson(otherMember, room)
 
         }
 

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -80,7 +80,7 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
         for (room in ChatkitManager.currentUser!!.rooms) {
 
-            val otherMemberId = room.memberUserIds.find { userId-> userId != ChatkitManager.currentUser!!.id }
+            val otherMemberId = room.memberUserIds.find { userId-> userId != ChatkitManager.currentUser!!.id }!!
 
             if (otherMemberId == null) {
                 val error = "Couldn't find any other people in room " + room.name

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -16,7 +16,7 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
         fun onConnected(user: CurrentUser)
         fun onError(error: String)
         fun onMemberPresenceChanged(user: User)
-        fun onPerson(user: User, room: Room)
+        fun onBuyer(user: User, room: Room)
         fun onUnreadCountChanged(room: Room)
     }
 
@@ -80,7 +80,7 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
             val otherMemberId = room.memberUserIds.find { userId-> userId != ChatkitManager.currentUser!!.id }!!
             val otherMember = buyers.find{ user -> user.id == otherMemberId}!!
-            view?.onPerson(otherMember, room)
+            view?.onBuyer(otherMember, room)
 
         }
 

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -63,9 +63,9 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
         ChatkitManager.addChatListener(chatListeners)
 
-        ChatkitManager.getAllUsersInitialState(object: ChatkitManager.ChatManagerAllUsersListener{
-            override fun onUsers(users: List<User>) {
-                reconcileUsers(users)
+        ChatkitManager.getUsersFromMyJoinedRooms(object: ChatkitManager.JoinedRoomsMembersListener {
+            override fun onMembersFetched(members: List<User>) {
+                reconcileUsers(members)
             }
 
             override fun onError(error: String) {

--- a/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
+++ b/app/src/main/java/com/pusher/demo/features/marketplace/seller/SellerPresenter.kt
@@ -9,8 +9,11 @@ import com.pusher.chatkit.rooms.Room
 import com.pusher.chatkit.users.User
 import com.pusher.demo.features.BasePresenter
 import com.pusher.demo.features.marketplace.ChatkitManager
+import com.pusher.util.Result
 
 class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
+
+    val LOG_TAG = "DEMO_APP"
 
     interface View {
         fun onConnected(user: CurrentUser)
@@ -61,17 +64,22 @@ class SellerPresenter :  BasePresenter<SellerPresenter.View>(){
 
         ChatkitManager.addChatListener(chatListeners)
 
-        ChatkitManager.getUsersFromMyJoinedRooms(object: ChatkitManager.JoinedRoomsMembersListener {
-            override fun onMembersFetched(members: List<User>) {
-                reconcileFetchedBuyers(members)
+        getUsersFromMyJoinedRooms()
+
+    }
+
+    private fun getUsersFromMyJoinedRooms() {
+        ChatkitManager.currentUser!!.users {
+            when (it) {
+                is Result.Success -> {
+                    reconcileFetchedBuyers(it.value)
+                }
+                is Result.Failure -> {
+                    Log.d(LOG_TAG, "error fetching users from rooms you have joined: "
+                            + it.error.reason)
+                }
             }
-
-            override fun onError(error: String) {
-                //todo: handle this D:
-            }
-
-        })
-
+        }
     }
 
     private fun reconcileFetchedBuyers(buyers: List<User>) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        //todo: remove this before releasing
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
### What
Refactor the Seller Activity to use the v7 memberships update. This means we no longer need to subscribe to each room to get the unread counts and members  🎉 

There was some complexity to resolve the user_ids we receive as members, and the initial User list we can request. I don't think this solution would work for developers with lots of rooms with many people in them, but works okay for our marketplace use case. I think we should ensure this is easier to do in v2 of the SDK.

Additionally, I have added a list of listeners into my `ChatkitManager` - in the Seller Activity I create my listener and the ChatkitManager then knows to send it down any updates. I then remove this listener when the activity is destroyed. Does this work? Is there anything better I could have done here?

I also fixed a nitpick where if you had more than 1 rooms the plurals string didn't work properly (it said `%d people are interested` instead of `2 people are interested`)

### Why:
We wanted to ensure that consuming the new version of the SDK didn't introduce any issues.

### Note:
To test the memberships earlier, I have used jitpack and consumed a specific git commit for the library (last commit to the branch). To release this PR, after we release the next version of chatkit android, we need to update this dependency.